### PR TITLE
Updated all references to the correct GH organization and repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,393 +2,393 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [1.2.2](https://github.com/dnb-org/dnb-hugo-hooks/compare/v1.0.27...v1.2.2) (2022-04-07)
+### [1.2.2](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.27...v1.2.2) (2022-04-07)
 
 
 ### Features
 
-* add version number in partial func/hooks/version.html ([c69ebd0](https://github.com/dnb-org/dnb-hugo-hooks/commit/c69ebd050b57d314d6345d5fb5e3429ce8eb968a))
+* add version number in partial func/hooks/version.html ([c69ebd0](https://github.com/davidsneighbour/hugo-hooks/commit/c69ebd050b57d314d6345d5fb5e3429ce8eb968a))
 
 
 ### Build System
 
-* **fix:** add proper data directory ([4b21855](https://github.com/dnb-org/dnb-hugo-hooks/commit/4b2185532ecac118bad341f5c5fed4ce549d8ca0))
+* **fix:** add proper data directory ([4b21855](https://github.com/davidsneighbour/hugo-hooks/commit/4b2185532ecac118bad341f5c5fed4ce549d8ca0))
 
 
 ### Documentation
 
-* update README.md ([54d4acc](https://github.com/dnb-org/dnb-hugo-hooks/commit/54d4accc385a9231af124f602a2df4c424dc13a0))
-* update README.md ([2b88908](https://github.com/dnb-org/dnb-hugo-hooks/commit/2b8890858026c7243eacad05e8535c21c1304a59))
-* update README.md ([013b3a9](https://github.com/dnb-org/dnb-hugo-hooks/commit/013b3a9e4b8fcd4dbe6e2a43a2e725666515cffb))
+* update README.md ([54d4acc](https://github.com/davidsneighbour/hugo-hooks/commit/54d4accc385a9231af124f602a2df4c424dc13a0))
+* update README.md ([2b88908](https://github.com/davidsneighbour/hugo-hooks/commit/2b8890858026c7243eacad05e8535c21c1304a59))
+* update README.md ([013b3a9](https://github.com/davidsneighbour/hugo-hooks/commit/013b3a9e4b8fcd4dbe6e2a43a2e725666515cffb))
 
 
 ### Chore
 
-* **config:** update dependabot configuration to run monthly ([4656237](https://github.com/dnb-org/dnb-hugo-hooks/commit/46562374780a1083b4a58cf5f49fefb8d16b3cfe))
-* **deps:** update dependencies ([44f1665](https://github.com/dnb-org/dnb-hugo-hooks/commit/44f16651f475c0e9e0bbff34990045e9bc3ca352))
-* **deps:** update dependencies ([6f282b3](https://github.com/dnb-org/dnb-hugo-hooks/commit/6f282b39bb1c47526da2c80180880b3bca384db8))
-* **deps:** update dependencies ([59c2344](https://github.com/dnb-org/dnb-hugo-hooks/commit/59c2344bc2b46d68fcf6719354ec337bb0945c8a))
-* **deps:** update dependencies ([7ee6b78](https://github.com/dnb-org/dnb-hugo-hooks/commit/7ee6b7886ad09100ea18e2c5e7acb6d9d99c11d4))
-* **deps:** update go module dependencies ([30f60de](https://github.com/dnb-org/dnb-hugo-hooks/commit/30f60de579d4ecedfe86ea7ae576991d5261f348))
-* **deps:** update module dependencies ([ee812c5](https://github.com/dnb-org/dnb-hugo-hooks/commit/ee812c50cac632d01d150e387cb648feff85c38d))
-* **release:** v1.0.28 ([959c2f1](https://github.com/dnb-org/dnb-hugo-hooks/commit/959c2f198f2ae97a7ab81bab68e66eeb676b802a))
-* **release:** v1.1.0 ([1371b4a](https://github.com/dnb-org/dnb-hugo-hooks/commit/1371b4af30b8e20d3c930d1ca0a3a1d732408d3b))
-* **release:** v1.1.1 ([3982159](https://github.com/dnb-org/dnb-hugo-hooks/commit/3982159f78fe06512ee1fdebbad4d6909d0a3078))
-* **release:** v1.2.0 ([c1c90fb](https://github.com/dnb-org/dnb-hugo-hooks/commit/c1c90fbc1d88159d669752024391cff669591b13))
-* **release:** v1.2.1 ([c00f369](https://github.com/dnb-org/dnb-hugo-hooks/commit/c00f3698b99730ccc4d15ac6067a3778d601585e))
-* update go.mod ([24f9fa8](https://github.com/dnb-org/dnb-hugo-hooks/commit/24f9fa88e9672c1f2ad487f1b6ec252881d00e0a))
-* updates and repo-renames ([64ec8dc](https://github.com/dnb-org/dnb-hugo-hooks/commit/64ec8dcf38f6c96cbdd5613979e75786949b35ca))
+* **config:** update dependabot configuration to run monthly ([4656237](https://github.com/davidsneighbour/hugo-hooks/commit/46562374780a1083b4a58cf5f49fefb8d16b3cfe))
+* **deps:** update dependencies ([44f1665](https://github.com/davidsneighbour/hugo-hooks/commit/44f16651f475c0e9e0bbff34990045e9bc3ca352))
+* **deps:** update dependencies ([6f282b3](https://github.com/davidsneighbour/hugo-hooks/commit/6f282b39bb1c47526da2c80180880b3bca384db8))
+* **deps:** update dependencies ([59c2344](https://github.com/davidsneighbour/hugo-hooks/commit/59c2344bc2b46d68fcf6719354ec337bb0945c8a))
+* **deps:** update dependencies ([7ee6b78](https://github.com/davidsneighbour/hugo-hooks/commit/7ee6b7886ad09100ea18e2c5e7acb6d9d99c11d4))
+* **deps:** update go module dependencies ([30f60de](https://github.com/davidsneighbour/hugo-hooks/commit/30f60de579d4ecedfe86ea7ae576991d5261f348))
+* **deps:** update module dependencies ([ee812c5](https://github.com/davidsneighbour/hugo-hooks/commit/ee812c50cac632d01d150e387cb648feff85c38d))
+* **release:** v1.0.28 ([959c2f1](https://github.com/davidsneighbour/hugo-hooks/commit/959c2f198f2ae97a7ab81bab68e66eeb676b802a))
+* **release:** v1.1.0 ([1371b4a](https://github.com/davidsneighbour/hugo-hooks/commit/1371b4af30b8e20d3c930d1ca0a3a1d732408d3b))
+* **release:** v1.1.1 ([3982159](https://github.com/davidsneighbour/hugo-hooks/commit/3982159f78fe06512ee1fdebbad4d6909d0a3078))
+* **release:** v1.2.0 ([c1c90fb](https://github.com/davidsneighbour/hugo-hooks/commit/c1c90fbc1d88159d669752024391cff669591b13))
+* **release:** v1.2.1 ([c00f369](https://github.com/davidsneighbour/hugo-hooks/commit/c00f3698b99730ccc4d15ac6067a3778d601585e))
+* update go.mod ([24f9fa8](https://github.com/davidsneighbour/hugo-hooks/commit/24f9fa88e9672c1f2ad487f1b6ec252881d00e0a))
+* updates and repo-renames ([64ec8dc](https://github.com/davidsneighbour/hugo-hooks/commit/64ec8dcf38f6c96cbdd5613979e75786949b35ca))
 
-### [1.2.1](https://github.com/dnb-org/dnb-hugo-hooks/compare/v1.0.27...v1.2.1) (2022-04-07)
+### [1.2.1](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.27...v1.2.1) (2022-04-07)
 
 
 ### Features
 
-* add version number in partial func/hooks/version.html ([c69ebd0](https://github.com/dnb-org/dnb-hugo-hooks/commit/c69ebd050b57d314d6345d5fb5e3429ce8eb968a))
+* add version number in partial func/hooks/version.html ([c69ebd0](https://github.com/davidsneighbour/hugo-hooks/commit/c69ebd050b57d314d6345d5fb5e3429ce8eb968a))
 
 
 ### Build System
 
-* **fix:** add proper data directory ([4b21855](https://github.com/dnb-org/dnb-hugo-hooks/commit/4b2185532ecac118bad341f5c5fed4ce549d8ca0))
+* **fix:** add proper data directory ([4b21855](https://github.com/davidsneighbour/hugo-hooks/commit/4b2185532ecac118bad341f5c5fed4ce549d8ca0))
 
 
 ### Documentation
 
-* update README.md ([54d4acc](https://github.com/dnb-org/dnb-hugo-hooks/commit/54d4accc385a9231af124f602a2df4c424dc13a0))
-* update README.md ([2b88908](https://github.com/dnb-org/dnb-hugo-hooks/commit/2b8890858026c7243eacad05e8535c21c1304a59))
-* update README.md ([013b3a9](https://github.com/dnb-org/dnb-hugo-hooks/commit/013b3a9e4b8fcd4dbe6e2a43a2e725666515cffb))
+* update README.md ([54d4acc](https://github.com/davidsneighbour/hugo-hooks/commit/54d4accc385a9231af124f602a2df4c424dc13a0))
+* update README.md ([2b88908](https://github.com/davidsneighbour/hugo-hooks/commit/2b8890858026c7243eacad05e8535c21c1304a59))
+* update README.md ([013b3a9](https://github.com/davidsneighbour/hugo-hooks/commit/013b3a9e4b8fcd4dbe6e2a43a2e725666515cffb))
 
 
 ### Chore
 
-* **config:** update dependabot configuration to run monthly ([4656237](https://github.com/dnb-org/dnb-hugo-hooks/commit/46562374780a1083b4a58cf5f49fefb8d16b3cfe))
-* **deps:** update dependencies ([44f1665](https://github.com/dnb-org/dnb-hugo-hooks/commit/44f16651f475c0e9e0bbff34990045e9bc3ca352))
-* **deps:** update dependencies ([6f282b3](https://github.com/dnb-org/dnb-hugo-hooks/commit/6f282b39bb1c47526da2c80180880b3bca384db8))
-* **deps:** update dependencies ([59c2344](https://github.com/dnb-org/dnb-hugo-hooks/commit/59c2344bc2b46d68fcf6719354ec337bb0945c8a))
-* **deps:** update dependencies ([7ee6b78](https://github.com/dnb-org/dnb-hugo-hooks/commit/7ee6b7886ad09100ea18e2c5e7acb6d9d99c11d4))
-* **deps:** update go module dependencies ([30f60de](https://github.com/dnb-org/dnb-hugo-hooks/commit/30f60de579d4ecedfe86ea7ae576991d5261f348))
-* **deps:** update module dependencies ([ee812c5](https://github.com/dnb-org/dnb-hugo-hooks/commit/ee812c50cac632d01d150e387cb648feff85c38d))
-* **release:** v1.0.28 ([959c2f1](https://github.com/dnb-org/dnb-hugo-hooks/commit/959c2f198f2ae97a7ab81bab68e66eeb676b802a))
-* **release:** v1.1.0 ([1371b4a](https://github.com/dnb-org/dnb-hugo-hooks/commit/1371b4af30b8e20d3c930d1ca0a3a1d732408d3b))
-* **release:** v1.1.1 ([3982159](https://github.com/dnb-org/dnb-hugo-hooks/commit/3982159f78fe06512ee1fdebbad4d6909d0a3078))
-* **release:** v1.2.0 ([c1c90fb](https://github.com/dnb-org/dnb-hugo-hooks/commit/c1c90fbc1d88159d669752024391cff669591b13))
-* update go.mod ([24f9fa8](https://github.com/dnb-org/dnb-hugo-hooks/commit/24f9fa88e9672c1f2ad487f1b6ec252881d00e0a))
-* updates and repo-renames ([64ec8dc](https://github.com/dnb-org/dnb-hugo-hooks/commit/64ec8dcf38f6c96cbdd5613979e75786949b35ca))
+* **config:** update dependabot configuration to run monthly ([4656237](https://github.com/davidsneighbour/hugo-hooks/commit/46562374780a1083b4a58cf5f49fefb8d16b3cfe))
+* **deps:** update dependencies ([44f1665](https://github.com/davidsneighbour/hugo-hooks/commit/44f16651f475c0e9e0bbff34990045e9bc3ca352))
+* **deps:** update dependencies ([6f282b3](https://github.com/davidsneighbour/hugo-hooks/commit/6f282b39bb1c47526da2c80180880b3bca384db8))
+* **deps:** update dependencies ([59c2344](https://github.com/davidsneighbour/hugo-hooks/commit/59c2344bc2b46d68fcf6719354ec337bb0945c8a))
+* **deps:** update dependencies ([7ee6b78](https://github.com/davidsneighbour/hugo-hooks/commit/7ee6b7886ad09100ea18e2c5e7acb6d9d99c11d4))
+* **deps:** update go module dependencies ([30f60de](https://github.com/davidsneighbour/hugo-hooks/commit/30f60de579d4ecedfe86ea7ae576991d5261f348))
+* **deps:** update module dependencies ([ee812c5](https://github.com/davidsneighbour/hugo-hooks/commit/ee812c50cac632d01d150e387cb648feff85c38d))
+* **release:** v1.0.28 ([959c2f1](https://github.com/davidsneighbour/hugo-hooks/commit/959c2f198f2ae97a7ab81bab68e66eeb676b802a))
+* **release:** v1.1.0 ([1371b4a](https://github.com/davidsneighbour/hugo-hooks/commit/1371b4af30b8e20d3c930d1ca0a3a1d732408d3b))
+* **release:** v1.1.1 ([3982159](https://github.com/davidsneighbour/hugo-hooks/commit/3982159f78fe06512ee1fdebbad4d6909d0a3078))
+* **release:** v1.2.0 ([c1c90fb](https://github.com/davidsneighbour/hugo-hooks/commit/c1c90fbc1d88159d669752024391cff669591b13))
+* update go.mod ([24f9fa8](https://github.com/davidsneighbour/hugo-hooks/commit/24f9fa88e9672c1f2ad487f1b6ec252881d00e0a))
+* updates and repo-renames ([64ec8dc](https://github.com/davidsneighbour/hugo-hooks/commit/64ec8dcf38f6c96cbdd5613979e75786949b35ca))
 
-## [1.2.0](https://github.com/dnb-org/dnb-hugo-hooks/compare/v1.0.27...v1.2.0) (2022-04-07)
+## [1.2.0](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.27...v1.2.0) (2022-04-07)
 
 
 ### Features
 
-* add version number in partial func/hooks/version.html ([c69ebd0](https://github.com/dnb-org/dnb-hugo-hooks/commit/c69ebd050b57d314d6345d5fb5e3429ce8eb968a))
+* add version number in partial func/hooks/version.html ([c69ebd0](https://github.com/davidsneighbour/hugo-hooks/commit/c69ebd050b57d314d6345d5fb5e3429ce8eb968a))
 
 
 ### Build System
 
-* **fix:** add proper data directory ([4b21855](https://github.com/dnb-org/dnb-hugo-hooks/commit/4b2185532ecac118bad341f5c5fed4ce549d8ca0))
+* **fix:** add proper data directory ([4b21855](https://github.com/davidsneighbour/hugo-hooks/commit/4b2185532ecac118bad341f5c5fed4ce549d8ca0))
 
 
 ### Documentation
 
-* update README.md ([54d4acc](https://github.com/dnb-org/dnb-hugo-hooks/commit/54d4accc385a9231af124f602a2df4c424dc13a0))
-* update README.md ([2b88908](https://github.com/dnb-org/dnb-hugo-hooks/commit/2b8890858026c7243eacad05e8535c21c1304a59))
-* update README.md ([013b3a9](https://github.com/dnb-org/dnb-hugo-hooks/commit/013b3a9e4b8fcd4dbe6e2a43a2e725666515cffb))
+* update README.md ([54d4acc](https://github.com/davidsneighbour/hugo-hooks/commit/54d4accc385a9231af124f602a2df4c424dc13a0))
+* update README.md ([2b88908](https://github.com/davidsneighbour/hugo-hooks/commit/2b8890858026c7243eacad05e8535c21c1304a59))
+* update README.md ([013b3a9](https://github.com/davidsneighbour/hugo-hooks/commit/013b3a9e4b8fcd4dbe6e2a43a2e725666515cffb))
 
 
 ### Chore
 
-* **config:** update dependabot configuration to run monthly ([4656237](https://github.com/dnb-org/dnb-hugo-hooks/commit/46562374780a1083b4a58cf5f49fefb8d16b3cfe))
-* **deps:** update dependencies ([44f1665](https://github.com/dnb-org/dnb-hugo-hooks/commit/44f16651f475c0e9e0bbff34990045e9bc3ca352))
-* **deps:** update dependencies ([6f282b3](https://github.com/dnb-org/dnb-hugo-hooks/commit/6f282b39bb1c47526da2c80180880b3bca384db8))
-* **deps:** update dependencies ([59c2344](https://github.com/dnb-org/dnb-hugo-hooks/commit/59c2344bc2b46d68fcf6719354ec337bb0945c8a))
-* **deps:** update dependencies ([7ee6b78](https://github.com/dnb-org/dnb-hugo-hooks/commit/7ee6b7886ad09100ea18e2c5e7acb6d9d99c11d4))
-* **deps:** update module dependencies ([ee812c5](https://github.com/dnb-org/dnb-hugo-hooks/commit/ee812c50cac632d01d150e387cb648feff85c38d))
-* **release:** v1.0.28 ([959c2f1](https://github.com/dnb-org/dnb-hugo-hooks/commit/959c2f198f2ae97a7ab81bab68e66eeb676b802a))
-* **release:** v1.1.0 ([1371b4a](https://github.com/dnb-org/dnb-hugo-hooks/commit/1371b4af30b8e20d3c930d1ca0a3a1d732408d3b))
-* **release:** v1.1.1 ([3982159](https://github.com/dnb-org/dnb-hugo-hooks/commit/3982159f78fe06512ee1fdebbad4d6909d0a3078))
-* update go.mod ([24f9fa8](https://github.com/dnb-org/dnb-hugo-hooks/commit/24f9fa88e9672c1f2ad487f1b6ec252881d00e0a))
-* updates and repo-renames ([64ec8dc](https://github.com/dnb-org/dnb-hugo-hooks/commit/64ec8dcf38f6c96cbdd5613979e75786949b35ca))
+* **config:** update dependabot configuration to run monthly ([4656237](https://github.com/davidsneighbour/hugo-hooks/commit/46562374780a1083b4a58cf5f49fefb8d16b3cfe))
+* **deps:** update dependencies ([44f1665](https://github.com/davidsneighbour/hugo-hooks/commit/44f16651f475c0e9e0bbff34990045e9bc3ca352))
+* **deps:** update dependencies ([6f282b3](https://github.com/davidsneighbour/hugo-hooks/commit/6f282b39bb1c47526da2c80180880b3bca384db8))
+* **deps:** update dependencies ([59c2344](https://github.com/davidsneighbour/hugo-hooks/commit/59c2344bc2b46d68fcf6719354ec337bb0945c8a))
+* **deps:** update dependencies ([7ee6b78](https://github.com/davidsneighbour/hugo-hooks/commit/7ee6b7886ad09100ea18e2c5e7acb6d9d99c11d4))
+* **deps:** update module dependencies ([ee812c5](https://github.com/davidsneighbour/hugo-hooks/commit/ee812c50cac632d01d150e387cb648feff85c38d))
+* **release:** v1.0.28 ([959c2f1](https://github.com/davidsneighbour/hugo-hooks/commit/959c2f198f2ae97a7ab81bab68e66eeb676b802a))
+* **release:** v1.1.0 ([1371b4a](https://github.com/davidsneighbour/hugo-hooks/commit/1371b4af30b8e20d3c930d1ca0a3a1d732408d3b))
+* **release:** v1.1.1 ([3982159](https://github.com/davidsneighbour/hugo-hooks/commit/3982159f78fe06512ee1fdebbad4d6909d0a3078))
+* update go.mod ([24f9fa8](https://github.com/davidsneighbour/hugo-hooks/commit/24f9fa88e9672c1f2ad487f1b6ec252881d00e0a))
+* updates and repo-renames ([64ec8dc](https://github.com/davidsneighbour/hugo-hooks/commit/64ec8dcf38f6c96cbdd5613979e75786949b35ca))
 
-### [1.1.1](https://github.com/dnb-org/dnb-hugo-hooks/compare/v1.0.27...v1.1.1) (2022-04-06)
+### [1.1.1](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.27...v1.1.1) (2022-04-06)
 
 
 ### Features
 
-* add version number in partial func/hooks/version.html ([c69ebd0](https://github.com/dnb-org/dnb-hugo-hooks/commit/c69ebd050b57d314d6345d5fb5e3429ce8eb968a))
+* add version number in partial func/hooks/version.html ([c69ebd0](https://github.com/davidsneighbour/hugo-hooks/commit/c69ebd050b57d314d6345d5fb5e3429ce8eb968a))
 
 
 ### Build System
 
-* **fix:** add proper data directory ([4b21855](https://github.com/dnb-org/dnb-hugo-hooks/commit/4b2185532ecac118bad341f5c5fed4ce549d8ca0))
+* **fix:** add proper data directory ([4b21855](https://github.com/davidsneighbour/hugo-hooks/commit/4b2185532ecac118bad341f5c5fed4ce549d8ca0))
 
 
 ### Documentation
 
-* update README.md ([54d4acc](https://github.com/dnb-org/dnb-hugo-hooks/commit/54d4accc385a9231af124f602a2df4c424dc13a0))
-* update README.md ([2b88908](https://github.com/dnb-org/dnb-hugo-hooks/commit/2b8890858026c7243eacad05e8535c21c1304a59))
-* update README.md ([013b3a9](https://github.com/dnb-org/dnb-hugo-hooks/commit/013b3a9e4b8fcd4dbe6e2a43a2e725666515cffb))
+* update README.md ([54d4acc](https://github.com/davidsneighbour/hugo-hooks/commit/54d4accc385a9231af124f602a2df4c424dc13a0))
+* update README.md ([2b88908](https://github.com/davidsneighbour/hugo-hooks/commit/2b8890858026c7243eacad05e8535c21c1304a59))
+* update README.md ([013b3a9](https://github.com/davidsneighbour/hugo-hooks/commit/013b3a9e4b8fcd4dbe6e2a43a2e725666515cffb))
 
 
 ### Chore
 
-* **config:** update dependabot configuration to run monthly ([4656237](https://github.com/dnb-org/dnb-hugo-hooks/commit/46562374780a1083b4a58cf5f49fefb8d16b3cfe))
-* **deps:** update dependencies ([44f1665](https://github.com/dnb-org/dnb-hugo-hooks/commit/44f16651f475c0e9e0bbff34990045e9bc3ca352))
-* **deps:** update dependencies ([6f282b3](https://github.com/dnb-org/dnb-hugo-hooks/commit/6f282b39bb1c47526da2c80180880b3bca384db8))
-* **deps:** update dependencies ([59c2344](https://github.com/dnb-org/dnb-hugo-hooks/commit/59c2344bc2b46d68fcf6719354ec337bb0945c8a))
-* **deps:** update dependencies ([7ee6b78](https://github.com/dnb-org/dnb-hugo-hooks/commit/7ee6b7886ad09100ea18e2c5e7acb6d9d99c11d4))
-* **deps:** update module dependencies ([ee812c5](https://github.com/dnb-org/dnb-hugo-hooks/commit/ee812c50cac632d01d150e387cb648feff85c38d))
-* **release:** v1.0.28 ([959c2f1](https://github.com/dnb-org/dnb-hugo-hooks/commit/959c2f198f2ae97a7ab81bab68e66eeb676b802a))
-* **release:** v1.1.0 ([1371b4a](https://github.com/dnb-org/dnb-hugo-hooks/commit/1371b4af30b8e20d3c930d1ca0a3a1d732408d3b))
-* update go.mod ([24f9fa8](https://github.com/dnb-org/dnb-hugo-hooks/commit/24f9fa88e9672c1f2ad487f1b6ec252881d00e0a))
+* **config:** update dependabot configuration to run monthly ([4656237](https://github.com/davidsneighbour/hugo-hooks/commit/46562374780a1083b4a58cf5f49fefb8d16b3cfe))
+* **deps:** update dependencies ([44f1665](https://github.com/davidsneighbour/hugo-hooks/commit/44f16651f475c0e9e0bbff34990045e9bc3ca352))
+* **deps:** update dependencies ([6f282b3](https://github.com/davidsneighbour/hugo-hooks/commit/6f282b39bb1c47526da2c80180880b3bca384db8))
+* **deps:** update dependencies ([59c2344](https://github.com/davidsneighbour/hugo-hooks/commit/59c2344bc2b46d68fcf6719354ec337bb0945c8a))
+* **deps:** update dependencies ([7ee6b78](https://github.com/davidsneighbour/hugo-hooks/commit/7ee6b7886ad09100ea18e2c5e7acb6d9d99c11d4))
+* **deps:** update module dependencies ([ee812c5](https://github.com/davidsneighbour/hugo-hooks/commit/ee812c50cac632d01d150e387cb648feff85c38d))
+* **release:** v1.0.28 ([959c2f1](https://github.com/davidsneighbour/hugo-hooks/commit/959c2f198f2ae97a7ab81bab68e66eeb676b802a))
+* **release:** v1.1.0 ([1371b4a](https://github.com/davidsneighbour/hugo-hooks/commit/1371b4af30b8e20d3c930d1ca0a3a1d732408d3b))
+* update go.mod ([24f9fa8](https://github.com/davidsneighbour/hugo-hooks/commit/24f9fa88e9672c1f2ad487f1b6ec252881d00e0a))
 
-## [1.1.0](https://github.com/dnb-org/dnb-hugo-hooks/compare/v1.0.27...v1.1.0) (2022-01-27)
+## [1.1.0](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.27...v1.1.0) (2022-01-27)
 
 
 ### Build System
 
-* **fix:** add proper data directory ([4b21855](https://github.com/dnb-org/dnb-hugo-hooks/commit/4b2185532ecac118bad341f5c5fed4ce549d8ca0))
+* **fix:** add proper data directory ([4b21855](https://github.com/davidsneighbour/hugo-hooks/commit/4b2185532ecac118bad341f5c5fed4ce549d8ca0))
 
 
 ### Chore
 
-* **release:** v1.0.28 ([959c2f1](https://github.com/dnb-org/dnb-hugo-hooks/commit/959c2f198f2ae97a7ab81bab68e66eeb676b802a))
+* **release:** v1.0.28 ([959c2f1](https://github.com/davidsneighbour/hugo-hooks/commit/959c2f198f2ae97a7ab81bab68e66eeb676b802a))
 
 
 ### Documentation
 
-* update README.md ([54d4acc](https://github.com/dnb-org/dnb-hugo-hooks/commit/54d4accc385a9231af124f602a2df4c424dc13a0))
-* update README.md ([2b88908](https://github.com/dnb-org/dnb-hugo-hooks/commit/2b8890858026c7243eacad05e8535c21c1304a59))
-* update README.md ([013b3a9](https://github.com/dnb-org/dnb-hugo-hooks/commit/013b3a9e4b8fcd4dbe6e2a43a2e725666515cffb))
+* update README.md ([54d4acc](https://github.com/davidsneighbour/hugo-hooks/commit/54d4accc385a9231af124f602a2df4c424dc13a0))
+* update README.md ([2b88908](https://github.com/davidsneighbour/hugo-hooks/commit/2b8890858026c7243eacad05e8535c21c1304a59))
+* update README.md ([013b3a9](https://github.com/davidsneighbour/hugo-hooks/commit/013b3a9e4b8fcd4dbe6e2a43a2e725666515cffb))
 
-### [1.0.28](https://github.com/dnb-org/dnb-hugo-hooks/compare/v1.0.27...v1.0.28) (2022-01-27)
-
-
-### Build System
-
-* **fix:** add proper data directory ([4b21855](https://github.com/dnb-org/dnb-hugo-hooks/commit/4b2185532ecac118bad341f5c5fed4ce549d8ca0))
-
-### [1.0.27](https://github.com/dnb-org/dnb-hugo-hooks/compare/v1.0.26...v1.0.27) (2022-01-27)
+### [1.0.28](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.27...v1.0.28) (2022-01-27)
 
 
 ### Build System
 
-* add README.md to release ([4d4e96c](https://github.com/dnb-org/dnb-hugo-hooks/commit/4d4e96c62e90833d1db5ba3d538f30f627d19454))
+* **fix:** add proper data directory ([4b21855](https://github.com/davidsneighbour/hugo-hooks/commit/4b2185532ecac118bad341f5c5fed4ce549d8ca0))
 
-### [1.0.26](https://github.com/dnb-org/dnb-hugo-hooks/compare/v1.0.23...v1.0.26) (2022-01-27)
+### [1.0.27](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.26...v1.0.27) (2022-01-27)
+
+
+### Build System
+
+* add README.md to release ([4d4e96c](https://github.com/davidsneighbour/hugo-hooks/commit/4d4e96c62e90833d1db5ba3d538f30f627d19454))
+
+### [1.0.26](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.23...v1.0.26) (2022-01-27)
 
 
 ### Chore
 
-* **ci:** reset dependabot to weekly checks ([163a361](https://github.com/dnb-org/dnb-hugo-hooks/commit/163a361f153cfe03f262901e12539474ba8670d2))
-* **config:** add data mount ([2196cc8](https://github.com/dnb-org/dnb-hugo-hooks/commit/2196cc8690dbac2ad0b75dcdf879434e7c116606))
-* **config:** move build file to proper location ([0af9f16](https://github.com/dnb-org/dnb-hugo-hooks/commit/0af9f16c8da84aee9b719c93fa225def6bb9efc1))
-* **config:** remove vscode configuration ([7ad13aa](https://github.com/dnb-org/dnb-hugo-hooks/commit/7ad13aa9d2c522e349a1ea58338b62a3c2f81768))
-* **config:** update gitignore ([9a93894](https://github.com/dnb-org/dnb-hugo-hooks/commit/9a9389441df0b5ed04d91857db56f705d63fec5e))
-* **config:** update header images ([70a5b82](https://github.com/dnb-org/dnb-hugo-hooks/commit/70a5b825bb2f911d6349de04f330da4a5297442a))
-* **config:** update package files ([1c6fdf4](https://github.com/dnb-org/dnb-hugo-hooks/commit/1c6fdf47929f4b95f1ae90a7e2f5e57253d244af))
-* **deps:** update dependencies ([17fbde7](https://github.com/dnb-org/dnb-hugo-hooks/commit/17fbde73a68b1ab99ab34279126cd3e27eec4b36))
-* **deps:** update dependencies for dependabot ([2e89003](https://github.com/dnb-org/dnb-hugo-hooks/commit/2e890033383ea15d291cca0a80d11f63853d2fba))
-* **deps:** update dependencies for dependabot ([e47b9cf](https://github.com/dnb-org/dnb-hugo-hooks/commit/e47b9cfd9e566180da64382aaa54c34fd774ae41))
-* **deps:** update Go dependencies ([2f7b28e](https://github.com/dnb-org/dnb-hugo-hooks/commit/2f7b28e9e71712fd14ef76fb09d5d2dfe3437ba1))
-* **release:** v1.0.24 ([9b3127c](https://github.com/dnb-org/dnb-hugo-hooks/commit/9b3127c854ef6863fc400ea1f05cff2443ff4d37))
-* set default level of hook run notices to 9 ([48d3913](https://github.com/dnb-org/dnb-hugo-hooks/commit/48d391303db8ba49b5faf88f6ad3cd5167a224fb))
-* update repo files and documentation ([a4997d3](https://github.com/dnb-org/dnb-hugo-hooks/commit/a4997d3b5ce61059c502a6d53bd17565a927239f))
-* update repository files ([c4d0ec6](https://github.com/dnb-org/dnb-hugo-hooks/commit/c4d0ec67516e6901ffb262c4e74853636de16caf))
+* **ci:** reset dependabot to weekly checks ([163a361](https://github.com/davidsneighbour/hugo-hooks/commit/163a361f153cfe03f262901e12539474ba8670d2))
+* **config:** add data mount ([2196cc8](https://github.com/davidsneighbour/hugo-hooks/commit/2196cc8690dbac2ad0b75dcdf879434e7c116606))
+* **config:** move build file to proper location ([0af9f16](https://github.com/davidsneighbour/hugo-hooks/commit/0af9f16c8da84aee9b719c93fa225def6bb9efc1))
+* **config:** remove vscode configuration ([7ad13aa](https://github.com/davidsneighbour/hugo-hooks/commit/7ad13aa9d2c522e349a1ea58338b62a3c2f81768))
+* **config:** update gitignore ([9a93894](https://github.com/davidsneighbour/hugo-hooks/commit/9a9389441df0b5ed04d91857db56f705d63fec5e))
+* **config:** update header images ([70a5b82](https://github.com/davidsneighbour/hugo-hooks/commit/70a5b825bb2f911d6349de04f330da4a5297442a))
+* **config:** update package files ([1c6fdf4](https://github.com/davidsneighbour/hugo-hooks/commit/1c6fdf47929f4b95f1ae90a7e2f5e57253d244af))
+* **deps:** update dependencies ([17fbde7](https://github.com/davidsneighbour/hugo-hooks/commit/17fbde73a68b1ab99ab34279126cd3e27eec4b36))
+* **deps:** update dependencies for dependabot ([2e89003](https://github.com/davidsneighbour/hugo-hooks/commit/2e890033383ea15d291cca0a80d11f63853d2fba))
+* **deps:** update dependencies for dependabot ([e47b9cf](https://github.com/davidsneighbour/hugo-hooks/commit/e47b9cfd9e566180da64382aaa54c34fd774ae41))
+* **deps:** update Go dependencies ([2f7b28e](https://github.com/davidsneighbour/hugo-hooks/commit/2f7b28e9e71712fd14ef76fb09d5d2dfe3437ba1))
+* **release:** v1.0.24 ([9b3127c](https://github.com/davidsneighbour/hugo-hooks/commit/9b3127c854ef6863fc400ea1f05cff2443ff4d37))
+* set default level of hook run notices to 9 ([48d3913](https://github.com/davidsneighbour/hugo-hooks/commit/48d391303db8ba49b5faf88f6ad3cd5167a224fb))
+* update repo files and documentation ([a4997d3](https://github.com/davidsneighbour/hugo-hooks/commit/a4997d3b5ce61059c502a6d53bd17565a927239f))
+* update repository files ([c4d0ec6](https://github.com/davidsneighbour/hugo-hooks/commit/c4d0ec67516e6901ffb262c4e74853636de16caf))
 
 
 ### Build System
 
-* add dependabot configuration ([6d6c532](https://github.com/dnb-org/dnb-hugo-hooks/commit/6d6c532df9c71ee72a0ee519abfc8fe1cb8eb4d8))
-* add documentation update script to build system ([442a13e](https://github.com/dnb-org/dnb-hugo-hooks/commit/442a13ea8c8583c3a1b4466514cf55b64ee2b7d1))
-* move build files around and add docs preparation script ([209bdb8](https://github.com/dnb-org/dnb-hugo-hooks/commit/209bdb859b6525b69c04b380be1265b2df109a40))
-* move build scripts around ([a59be47](https://github.com/dnb-org/dnb-hugo-hooks/commit/a59be4739c4ce81cb8056a28d6c73b941405135a))
-* update release system ([3ca6f69](https://github.com/dnb-org/dnb-hugo-hooks/commit/3ca6f69d1c039ea0857a4c718de1aa44c144ecff))
+* add dependabot configuration ([6d6c532](https://github.com/davidsneighbour/hugo-hooks/commit/6d6c532df9c71ee72a0ee519abfc8fe1cb8eb4d8))
+* add documentation update script to build system ([442a13e](https://github.com/davidsneighbour/hugo-hooks/commit/442a13ea8c8583c3a1b4466514cf55b64ee2b7d1))
+* move build files around and add docs preparation script ([209bdb8](https://github.com/davidsneighbour/hugo-hooks/commit/209bdb859b6525b69c04b380be1265b2df109a40))
+* move build scripts around ([a59be47](https://github.com/davidsneighbour/hugo-hooks/commit/a59be4739c4ce81cb8056a28d6c73b941405135a))
+* update release system ([3ca6f69](https://github.com/davidsneighbour/hugo-hooks/commit/3ca6f69d1c039ea0857a4c718de1aa44c144ecff))
 
-### [1.0.25](https://github.com/dnb-org/dnb-org-hooks/compare/v1.0.23...v1.0.25) (2021-12-29)
-
-
-### Build System
-
-* add dependabot configuration ([6d6c532](https://github.com/dnb-org/dnb-org-hooks/commit/6d6c532df9c71ee72a0ee519abfc8fe1cb8eb4d8))
-* update release system ([3ca6f69](https://github.com/dnb-org/dnb-org-hooks/commit/3ca6f69d1c039ea0857a4c718de1aa44c144ecff))
-
-
-### Chore
-
-* **config:** update package files ([1c6fdf4](https://github.com/dnb-org/dnb-org-hooks/commit/1c6fdf47929f4b95f1ae90a7e2f5e57253d244af))
-* **deps:** update dependencies for dependabot ([e47b9cf](https://github.com/dnb-org/dnb-org-hooks/commit/e47b9cfd9e566180da64382aaa54c34fd774ae41))
-* **release:** v1.0.24 ([9b3127c](https://github.com/dnb-org/dnb-org-hooks/commit/9b3127c854ef6863fc400ea1f05cff2443ff4d37))
-* update repo files and documentation ([a4997d3](https://github.com/dnb-org/dnb-org-hooks/commit/a4997d3b5ce61059c502a6d53bd17565a927239f))
-
-### [1.0.24](https://github.com/dnb-org/dnb-org-hooks/compare/v1.0.23...v1.0.24) (2021-12-29)
+### [1.0.25](https://github.com/davidsneighbour/davidsneighbour-hooks/compare/v1.0.23...v1.0.25) (2021-12-29)
 
 
 ### Build System
 
-* add dependabot configuration ([6d6c532](https://github.com/dnb-org/dnb-org-hooks/commit/6d6c532df9c71ee72a0ee519abfc8fe1cb8eb4d8))
-* update release system ([3ca6f69](https://github.com/dnb-org/dnb-org-hooks/commit/3ca6f69d1c039ea0857a4c718de1aa44c144ecff))
+* add dependabot configuration ([6d6c532](https://github.com/davidsneighbour/davidsneighbour-hooks/commit/6d6c532df9c71ee72a0ee519abfc8fe1cb8eb4d8))
+* update release system ([3ca6f69](https://github.com/davidsneighbour/davidsneighbour-hooks/commit/3ca6f69d1c039ea0857a4c718de1aa44c144ecff))
 
 
 ### Chore
 
-* **config:** update package files ([1c6fdf4](https://github.com/dnb-org/dnb-org-hooks/commit/1c6fdf47929f4b95f1ae90a7e2f5e57253d244af))
-* update repo files and documentation ([a4997d3](https://github.com/dnb-org/dnb-org-hooks/commit/a4997d3b5ce61059c502a6d53bd17565a927239f))
+* **config:** update package files ([1c6fdf4](https://github.com/davidsneighbour/davidsneighbour-hooks/commit/1c6fdf47929f4b95f1ae90a7e2f5e57253d244af))
+* **deps:** update dependencies for dependabot ([e47b9cf](https://github.com/davidsneighbour/davidsneighbour-hooks/commit/e47b9cfd9e566180da64382aaa54c34fd774ae41))
+* **release:** v1.0.24 ([9b3127c](https://github.com/davidsneighbour/davidsneighbour-hooks/commit/9b3127c854ef6863fc400ea1f05cff2443ff4d37))
+* update repo files and documentation ([a4997d3](https://github.com/davidsneighbour/davidsneighbour-hooks/commit/a4997d3b5ce61059c502a6d53bd17565a927239f))
 
-### [1.0.23](https://github.com/dnb-org/dnb-org-hooks/compare/v1.0.22...v1.0.23) (2021-12-10)
+### [1.0.24](https://github.com/davidsneighbour/davidsneighbour-hooks/compare/v1.0.23...v1.0.24) (2021-12-29)
+
+
+### Build System
+
+* add dependabot configuration ([6d6c532](https://github.com/davidsneighbour/davidsneighbour-hooks/commit/6d6c532df9c71ee72a0ee519abfc8fe1cb8eb4d8))
+* update release system ([3ca6f69](https://github.com/davidsneighbour/davidsneighbour-hooks/commit/3ca6f69d1c039ea0857a4c718de1aa44c144ecff))
 
 
 ### Chore
 
-* **fix:** update module name in go.mod ([bff72df](https://github.com/dnb-org/dnb-org-hooks/commit/bff72dfa7793d576ef16fdbb8afe3e3cf57dfdcb))
+* **config:** update package files ([1c6fdf4](https://github.com/davidsneighbour/davidsneighbour-hooks/commit/1c6fdf47929f4b95f1ae90a7e2f5e57253d244af))
+* update repo files and documentation ([a4997d3](https://github.com/davidsneighbour/davidsneighbour-hooks/commit/a4997d3b5ce61059c502a6d53bd17565a927239f))
 
-### [1.0.22](https://github.com/dnb-org/dnb-org-hooks/compare/v1.0.21...v1.0.22) (2021-12-10)
+### [1.0.23](https://github.com/davidsneighbour/davidsneighbour-hooks/compare/v1.0.22...v1.0.23) (2021-12-10)
 
-### [1.0.21](https://github.com/dnb-hugo/hooks/compare/v1.0.20...v1.0.21) (2021-12-09)
+
+### Chore
+
+* **fix:** update module name in go.mod ([bff72df](https://github.com/davidsneighbour/davidsneighbour-hooks/commit/bff72dfa7793d576ef16fdbb8afe3e3cf57dfdcb))
+
+### [1.0.22](https://github.com/davidsneighbour/davidsneighbour-hooks/compare/v1.0.21...v1.0.22) (2021-12-10)
+
+### [1.0.21](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.20...v1.0.21) (2021-12-09)
 
 
 ### Documentation
 
-* add hooks and how often they run ([dd59667](https://github.com/dnb-hugo/hooks/commit/dd596671868f5848f30438ea678b91a292a403c7))
+* add hooks and how often they run ([dd59667](https://github.com/davidsneighbour/hugo-hooks/commit/dd596671868f5848f30438ea678b91a292a403c7))
 
 
 ### Chore
 
-* **config:** add vscode configuration ([60107d4](https://github.com/dnb-hugo/hooks/commit/60107d4ed7c39702a48da3c6206710e321bb8fbb))
-* **deps:** update dependencies ([eceaf8a](https://github.com/dnb-hugo/hooks/commit/eceaf8ae0ed1af310d1fc4a5ea4b05bd2d7c00b4))
-* **deps:** update dependencies and add lock file ([2906325](https://github.com/dnb-hugo/hooks/commit/2906325675227615c07034105f0fd9f5b52c5542))
-* update module dependencies ([1b3ea38](https://github.com/dnb-hugo/hooks/commit/1b3ea38e587ca907fa024ed0c4474197317a7eda))
+* **config:** add vscode configuration ([60107d4](https://github.com/davidsneighbour/hugo-hooks/commit/60107d4ed7c39702a48da3c6206710e321bb8fbb))
+* **deps:** update dependencies ([eceaf8a](https://github.com/davidsneighbour/hugo-hooks/commit/eceaf8ae0ed1af310d1fc4a5ea4b05bd2d7c00b4))
+* **deps:** update dependencies and add lock file ([2906325](https://github.com/davidsneighbour/hugo-hooks/commit/2906325675227615c07034105f0fd9f5b52c5542))
+* update module dependencies ([1b3ea38](https://github.com/davidsneighbour/hugo-hooks/commit/1b3ea38e587ca907fa024ed0c4474197317a7eda))
 
-### [1.0.20](https://github.com/dnb-hugo/hooks/compare/v1.0.19...v1.0.20) (2021-11-05)
-
-
-### Documentation
-
-* **fix:** markdown errors ([37e169a](https://github.com/dnb-hugo/hooks/commit/37e169a05735334ee78df3fc9f81b9ddb4565a3b))
-
-### [1.0.19](https://github.com/dnb-hugo/hooks/compare/v1.0.18...v1.0.19) (2021-11-05)
-
-### [1.0.18](https://github.com/dnb-hugo/hooks/compare/v1.0.17...v1.0.18) (2021-11-05)
+### [1.0.20](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.19...v1.0.20) (2021-11-05)
 
 
 ### Documentation
 
-* **fix:** hookname table is broken ([445db8d](https://github.com/dnb-hugo/hooks/commit/445db8d40bfe647e344b7a5b271091e744f726c2))
+* **fix:** markdown errors ([37e169a](https://github.com/davidsneighbour/hugo-hooks/commit/37e169a05735334ee78df3fc9f81b9ddb4565a3b))
 
-### [1.0.17](https://github.com/dnb-hugo/hooks/compare/v1.0.16...v1.0.17) (2021-11-05)
+### [1.0.19](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.18...v1.0.19) (2021-11-05)
+
+### [1.0.18](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.17...v1.0.18) (2021-11-05)
+
+
+### Documentation
+
+* **fix:** hookname table is broken ([445db8d](https://github.com/davidsneighbour/hugo-hooks/commit/445db8d40bfe647e344b7a5b271091e744f726c2))
+
+### [1.0.17](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.16...v1.0.17) (2021-11-05)
 
 
 ### Features
 
-* **layouts:** adding silence configuration ([f934f63](https://github.com/dnb-hugo/hooks/commit/f934f635ef2e77d1532cea0fb4d0a6525322ec3a)), closes [#4](https://github.com/dnb-hugo/hooks/issues/4)
+* **layouts:** adding silence configuration ([f934f63](https://github.com/davidsneighbour/hugo-hooks/commit/f934f635ef2e77d1532cea0fb4d0a6525322ec3a)), closes [#4](https://github.com/davidsneighbour/hugo-hooks/issues/4)
 
 
 ### Documentation
 
-* update documentation of configuration parameters ([e6bdac7](https://github.com/dnb-hugo/hooks/commit/e6bdac7f976726a1f02c63df70992c5a28d10422))
+* update documentation of configuration parameters ([e6bdac7](https://github.com/davidsneighbour/hugo-hooks/commit/e6bdac7f976726a1f02c63df70992c5a28d10422))
 
-### [1.0.16](https://github.com/dnb-hugo/hooks/compare/v1.0.15...v1.0.16) (2021-10-11)
-
-
-### Chore
-
-* **deps:** update dependencies ([0c83f1e](https://github.com/dnb-hugo/hooks/commit/0c83f1efef9d732e5d75b21d78a7aa8adcfeb0bc))
-
-### [1.0.15](https://github.com/dnb-hugo/hooks/compare/v1.0.14...v1.0.15) (2021-10-08)
+### [1.0.16](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.15...v1.0.16) (2021-10-11)
 
 
 ### Chore
 
-* add more debugging notes ([a77d5e6](https://github.com/dnb-hugo/hooks/commit/a77d5e63e8f8c7e9ebbe7c1358a819bcd0491b7c))
+* **deps:** update dependencies ([0c83f1e](https://github.com/davidsneighbour/hugo-hooks/commit/0c83f1efef9d732e5d75b21d78a7aa8adcfeb0bc))
 
-### [1.0.14](https://github.com/dnb-hugo/hooks/compare/v1.0.13...v1.0.14) (2021-10-08)
+### [1.0.15](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.14...v1.0.15) (2021-10-08)
 
 
 ### Chore
 
-* add clean routines to package.json ([fc6ec45](https://github.com/dnb-hugo/hooks/commit/fc6ec45e1eb4ab5794958d055c1e9662ca02dbe5))
+* add more debugging notes ([a77d5e6](https://github.com/davidsneighbour/hugo-hooks/commit/a77d5e63e8f8c7e9ebbe7c1358a819bcd0491b7c))
+
+### [1.0.14](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.13...v1.0.14) (2021-10-08)
+
+
+### Chore
+
+* add clean routines to package.json ([fc6ec45](https://github.com/davidsneighbour/hugo-hooks/commit/fc6ec45e1eb4ab5794958d055c1e9662ca02dbe5))
 
 
 ### Documentation
 
-* update README.md ([b1b1ca2](https://github.com/dnb-hugo/hooks/commit/b1b1ca2591ff80c7e47ac8c66d2acd55deccfa6b))
+* update README.md ([b1b1ca2](https://github.com/davidsneighbour/hugo-hooks/commit/b1b1ca2591ff80c7e47ac8c66d2acd55deccfa6b))
 
-### [1.0.13](https://github.com/dnb-hugo/hooks/compare/v1.0.12...v1.0.13) (2021-10-08)
-
-
-### Chore
-
-* **config:** move config into configuration directory ([8bee828](https://github.com/dnb-hugo/hooks/commit/8bee8283b797606ab088be029bf940006de1b686))
-* fix package.json ([e990b6b](https://github.com/dnb-hugo/hooks/commit/e990b6bbdec2f262557b10b8f1cef86341db7425))
-
-### [1.0.12](https://github.com/dnb-hugo/hooks/compare/v1.0.11...v1.0.12) (2021-10-03)
+### [1.0.13](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.12...v1.0.13) (2021-10-08)
 
 
 ### Chore
 
-* **deps:** update dependencies ([6adfd78](https://github.com/dnb-hugo/hooks/commit/6adfd78608392b40af0dc85112fc72b7503a11c5))
-* **deps:** update GoHugo modules ([0443d05](https://github.com/dnb-hugo/hooks/commit/0443d050358ce31444230a61f682dfe626e8cf61))
-* remove .idea directory ([fc8d98e](https://github.com/dnb-hugo/hooks/commit/fc8d98ec97a96a9cb99836d5fc1269dffc67a6f4))
-* update configuration ([cb304c8](https://github.com/dnb-hugo/hooks/commit/cb304c88b8deab5c221862a431216131348fdac0))
+* **config:** move config into configuration directory ([8bee828](https://github.com/davidsneighbour/hugo-hooks/commit/8bee8283b797606ab088be029bf940006de1b686))
+* fix package.json ([e990b6b](https://github.com/davidsneighbour/hugo-hooks/commit/e990b6bbdec2f262557b10b8f1cef86341db7425))
 
-### [1.0.11](https://github.com/dnb-hugo/hooks/compare/v1.0.10...v1.0.11) (2021-07-15)
+### [1.0.12](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.11...v1.0.12) (2021-10-03)
 
 
 ### Chore
 
-* move from dnb-hugo to dnb-org ([5f6a5c9](https://github.com/dnb-hugo/hooks/commit/5f6a5c956d4f4cf7c0a0ba3e16c99f6743e5bc10))
+* **deps:** update dependencies ([6adfd78](https://github.com/davidsneighbour/hugo-hooks/commit/6adfd78608392b40af0dc85112fc72b7503a11c5))
+* **deps:** update GoHugo modules ([0443d05](https://github.com/davidsneighbour/hugo-hooks/commit/0443d050358ce31444230a61f682dfe626e8cf61))
+* remove .idea directory ([fc8d98e](https://github.com/davidsneighbour/hugo-hooks/commit/fc8d98ec97a96a9cb99836d5fc1269dffc67a6f4))
+* update configuration ([cb304c8](https://github.com/davidsneighbour/hugo-hooks/commit/cb304c88b8deab5c221862a431216131348fdac0))
 
-### [1.0.9](https://github.com/dnb-org/hooks/compare/v1.0.8...v1.0.9) (2021-06-24)
+### [1.0.11](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.10...v1.0.11) (2021-07-15)
+
+
+### Chore
+
+* move from dnb-hugo to davidsneighbour ([5f6a5c9](https://github.com/davidsneighbour/hugo-hooks/commit/5f6a5c956d4f4cf7c0a0ba3e16c99f6743e5bc10))
+
+### [1.0.9](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.8...v1.0.9) (2021-06-24)
 
 
 ### Bug Fixes
 
-* remove version max restriction ([8090bed](https://github.com/dnb-org/hooks/commit/8090bed303e97a4c68d70ab8fa10998880ca0829))
+* remove version max restriction ([8090bed](https://github.com/davidsneighbour/hugo-hooks/commit/8090bed303e97a4c68d70ab8fa10998880ca0829))
 
-### [1.0.8](https://github.com/dnb-org/hooks/compare/v1.0.7...v1.0.8) (2021-06-22)
-
-
-### Bug Fixes
-
-* set max hugo version to 0.83.1 ([d5e8b64](https://github.com/dnb-org/hooks/commit/d5e8b646c899b3a89eeab07a89751cb548a719fd))
-
-### [1.0.7](https://github.com/dnb-org/hooks/compare/v1.0.6...v1.0.7) (2021-06-20)
+### [1.0.8](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.7...v1.0.8) (2021-06-22)
 
 
 ### Bug Fixes
 
-* hooklink config confusion ([4470e8e](https://github.com/dnb-org/hooks/commit/4470e8e7907fc4e079192a6347af737e463c0d9a))
+* set max hugo version to 0.83.1 ([d5e8b64](https://github.com/davidsneighbour/hugo-hooks/commit/d5e8b646c899b3a89eeab07a89751cb548a719fd))
+
+### [1.0.7](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.6...v1.0.7) (2021-06-20)
+
+
+### Bug Fixes
+
+* hooklink config confusion ([4470e8e](https://github.com/davidsneighbour/hugo-hooks/commit/4470e8e7907fc4e079192a6347af737e463c0d9a))
 
 
 ### Documentation
 
-* more badges ([41b75a6](https://github.com/dnb-org/hooks/commit/41b75a6d138b6aac14f0bc7fd5cb6b82bae49973))
+* more badges ([41b75a6](https://github.com/davidsneighbour/hugo-hooks/commit/41b75a6d138b6aac14f0bc7fd5cb6b82bae49973))
 
-### [1.0.6](https://github.com/dnb-org/hooks/compare/v1.0.5...v1.0.6) (2021-06-20)
+### [1.0.6](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.5...v1.0.6) (2021-06-20)
 
 
 ### Features
 
-* move hooklink configuration into internal configuration ([9f0a58f](https://github.com/dnb-org/hooks/commit/9f0a58f8d7e3d3b13b14ba2d24474c5cdf4cca7b))
+* move hooklink configuration into internal configuration ([9f0a58f](https://github.com/davidsneighbour/hugo-hooks/commit/9f0a58f8d7e3d3b13b14ba2d24474c5cdf4cca7b))
 
 
 ### Bug Fixes
 
-* set verbosity to 8 instead of 7 ([272bd22](https://github.com/dnb-org/hooks/commit/272bd2277e111414311cb0bc0c0ee7dabc183d7b))
+* set verbosity to 8 instead of 7 ([272bd22](https://github.com/davidsneighbour/hugo-hooks/commit/272bd2277e111414311cb0bc0c0ee7dabc183d7b))
 
 
 ### Documentation
 
-* **fix:** add code language to code blocks in README.md ([e65bcbf](https://github.com/dnb-org/hooks/commit/e65bcbf24e9747f338a8b9c3e6d9dfac5362cf15))
-* **fix:** add some fancy badges to README.md ([1c8c80e](https://github.com/dnb-org/hooks/commit/1c8c80e1dd5d150b3d65e45c64fb250cba2fcd34))
+* **fix:** add code language to code blocks in README.md ([e65bcbf](https://github.com/davidsneighbour/hugo-hooks/commit/e65bcbf24e9747f338a8b9c3e6d9dfac5362cf15))
+* **fix:** add some fancy badges to README.md ([1c8c80e](https://github.com/davidsneighbour/hugo-hooks/commit/1c8c80e1dd5d150b3d65e45c64fb250cba2fcd34))
 
 
 ### Chore
 
-* **deps:** update dependencies ([5d7a693](https://github.com/dnb-org/hooks/commit/5d7a6935a4b8e2212af8e050a84162ea15f3b156))
+* **deps:** update dependencies ([5d7a693](https://github.com/davidsneighbour/hugo-hooks/commit/5d7a6935a4b8e2212af8e050a84162ea15f3b156))
 
-### [1.0.5](https://github.com/dnb-org/hooks/compare/v1.0.4...v1.0.5) (2021-06-13)
+### [1.0.5](https://github.com/davidsneighbour/hugo-hooks/compare/v1.0.4...v1.0.5) (2021-06-13)
 
 
 ### Chore
 
-* cleanup and removing cruft ([48a94bf](https://github.com/dnb-org/hooks/commit/48a94bfdb06dd2bc7f9b93d7750dd6fdcf527d6d))
+* cleanup and removing cruft ([48a94bf](https://github.com/davidsneighbour/hugo-hooks/commit/48a94bfdb06dd2bc7f9b93d7750dd6fdcf527d6d))

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Hooks for GoHugo layouts. An easy way for theme developers to let users add to their themes.
 
-We often want to add locations and places in our templates and layouts where it's users can add something on their own. Be it some code for an analytics script,, that arbitrary ad or popup or just some space for call to actions or additional footer sections, a banner at the top of the page or some very specific Javascript code. `dnb-hugo-hooks` is what you need.
+We often want to add locations and places in our templates and layouts where it's users can add something on their own. Be it some code for an analytics script,, that arbitrary ad or popup or just some space for call to actions or additional footer sections, a banner at the top of the page or some very specific Javascript code. `hugo-hooks` is what you need.
 
 This module adds these hooks to your theme and provides a simple way **any theme developer** can add these "layout locations" to "hook" additional features in.
 
@@ -80,7 +80,7 @@ You can force caching by loading the hook via `partialCached` instead.
 {{ partialCached "func/hook" "head-start" "cachename"}}
 ```
 
-These hooks currently **do not return any values**, they execute the layouts. To read more about ideas to extend the hooks to return values read [#2 RFC: Hooks that return values](https://github.com/dnb-org/hooks/issues/2).
+These hooks currently **do not return any values**, they execute the layouts. To read more about ideas to extend the hooks to return values read [#2 RFC: Hooks that return values](https://github.com/davidsneighbour/hugo-hooks/issues/2).
 
 ## Simple Use
 
@@ -149,35 +149,35 @@ To be very portable between themes the following hooks should be used at the app
 
 <!--- COMPONENTS BEGIN --->
 
-## Other [GoHugo](https://gohugo.io/) components by [@dnb-org](https://github.com/dnb-org/)
+## Other [GoHugo](https://gohugo.io/) components by [@davidsneighbour](https://github.com/davidsneighbour/)
 
 <!-- prettier-ignore -->
 | Component | Description |
 | :--- | :--- |
-| [dnb-hugo-auditor](https://github.com/davidsneighbour/hugo-auditor) | |
-| [dnb-hugo-debug](https://github.com/davidsneighbour/hugo-debug) :mage_man: | Debug EVERYTHING in GoHugo. |
-| [dnb-hugo-errors](https://github.com/davidsneighbour/hugo-errors) | A Hugo module that adds more versatile error pages to a site. |
-| [dnb-hugo-feeds](https://github.com/davidsneighbour/hugo-feeds) | Implements various configurable feed formats. |
-| [dnb-hugo-functions](https://github.com/davidsneighbour/hugo-functions) | A Hugo theme component with helper functions for other projects. |
-| [dnb-hugo-giscus](https://github.com/davidsneighbour/hugo-giscus) | The Giscus comment system layout for GoHugo. |
-| [dnb-hugo-head](https://github.com/davidsneighbour/hugo-head) | A GoHugo theme component that solves the old question of "What tags belong into the `<head>` tag of my website?" |
-| [dnb-hugo-hooks](https://github.com/davidsneighbour/hugo-hooks) | Hooks for GoHugo layouts. An easy way for theme developers to let users add to their themes.  |
-| [dnb-hugo-humans](https://github.com/davidsneighbour/hugo-humans) | Your site is made by humans. Humans.txt is naming them. |
-| [dnb-hugo-icons](https://github.com/davidsneighbour/hugo-icons) | Icons for your Hugo website. |
-| [dnb-hugo-internals](https://github.com/davidsneighbour/hugo-internals) | Better internal templates for GoHugo |
-| [dnb-hugo-netlification](https://github.com/davidsneighbour/hugo-netlification) | a collection of tools that optimize your site on Netlify |
-| [dnb-hugo-opensearch](https://github.com/davidsneighbour/hugo-opensearch) | configuration for Open Search |
-| [dnb-hugo-pictures](https://github.com/davidsneighbour/hugo-pictures) | |
-| [dnb-hugo-pwa](https://github.com/davidsneighbour/hugo-pwa) | Automatically turns your site into a PWA |
-| [dnb-hugo-renderhooks](https://github.com/davidsneighbour/hugo-renderhooks) | render hooks for Markdown markup |
-| [dnb-hugo-robots](https://github.com/davidsneighbour/hugo-robots) | Add a customizable robots.txt to your website. |
-| [dnb-hugo-schema](https://github.com/davidsneighbour/hugo-schema) | |
-| [dnb-hugo-search-algolia](https://github.com/davidsneighbour/hugo-search-algolia) | |
-| [dnb-hugo-security](https://github.com/davidsneighbour/hugo-security) | Add a security.txt to your site with information about your preferred procedures to notify the developer team about security issues. |
-| [dnb-hugo-sitemap](https://github.com/davidsneighbour/hugo-sitemap) | |
-| [dnb-hugo-social](https://github.com/davidsneighbour/hugo-social) | |
-| [dnb-hugo-workflows](https://github.com/davidsneighbour/hugo-workflows) | A collection of Github Actions/Workflows to optimise your work with GoHugo. |
-| [dnb-hugo-youtube](https://github.com/davidsneighbour/hugo-youtube) | A shortcode and partial for lite and speedy youtube embeds. |
+| [hugo-auditor](https://github.com/davidsneighbour/hugo-auditor) | |
+| [hugo-debug](https://github.com/davidsneighbour/hugo-debug) :mage_man: | Debug EVERYTHING in GoHugo. |
+| [hugo-errors](https://github.com/davidsneighbour/hugo-errors) | A Hugo module that adds more versatile error pages to a site. |
+| [hugo-feeds](https://github.com/davidsneighbour/hugo-feeds) | Implements various configurable feed formats. |
+| [hugo-functions](https://github.com/davidsneighbour/hugo-functions) | A Hugo theme component with helper functions for other projects. |
+| [hugo-giscus](https://github.com/davidsneighbour/hugo-giscus) | The Giscus comment system layout for GoHugo. |
+| [hugo-head](https://github.com/davidsneighbour/hugo-head) | A GoHugo theme component that solves the old question of "What tags belong into the `<head>` tag of my website?" |
+| [hugo-hooks](https://github.com/davidsneighbour/hugo-hooks) | Hooks for GoHugo layouts. An easy way for theme developers to let users add to their themes.  |
+| [hugo-humans](https://github.com/davidsneighbour/hugo-humans) | Your site is made by humans. Humans.txt is naming them. |
+| [hugo-icons](https://github.com/davidsneighbour/hugo-icons) | Icons for your Hugo website. |
+| [hugo-internals](https://github.com/davidsneighbour/hugo-internals) | Better internal templates for GoHugo |
+| [hugo-netlification](https://github.com/davidsneighbour/hugo-netlification) | a collection of tools that optimize your site on Netlify |
+| [hugo-opensearch](https://github.com/davidsneighbour/hugo-opensearch) | configuration for Open Search |
+| [hugo-pictures](https://github.com/davidsneighbour/hugo-pictures) | |
+| [hugo-pwa](https://github.com/davidsneighbour/hugo-pwa) | Automatically turns your site into a PWA |
+| [hugo-renderhooks](https://github.com/davidsneighbour/hugo-renderhooks) | render hooks for Markdown markup |
+| [hugo-robots](https://github.com/davidsneighbour/hugo-robots) | Add a customizable robots.txt to your website. |
+| [hugo-schema](https://github.com/davidsneighbour/hugo-schema) | |
+| [hugo-search-algolia](https://github.com/davidsneighbour/hugo-search-algolia) | |
+| [hugo-security](https://github.com/davidsneighbour/hugo-security) | Add a security.txt to your site with information about your preferred procedures to notify the developer team about security issues. |
+| [hugo-sitemap](https://github.com/davidsneighbour/hugo-sitemap) | |
+| [hugo-social](https://github.com/davidsneighbour/hugo-social) | |
+| [hugo-workflows](https://github.com/davidsneighbour/hugo-workflows) | A collection of Github Actions/Workflows to optimise your work with GoHugo. |
+| [hugo-youtube](https://github.com/davidsneighbour/hugo-youtube) | A shortcode and partial for lite and speedy youtube embeds. |
 
 <!--lint disable no-missing-blank-lines -->
 <!--- COMPONENTS END --->


### PR DESCRIPTION
Updated all links to GH issues, GH organization and repository are updated to reflect the current state:
* GH org: `davidsneighbour` instead of `dnb-org`
* GH repo: `hugo-hooks` instead of `hooks` or `dnb-hugo-hooks`

I left the `@dnb-org` as the namespace in the NPM depencencies in `package.json` for now, as I didn't know what you intend to do with this.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>