### PR TITLE
Adding folder based hook system

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "**/layouts/**.html": "go"
+  }
+}

--- a/layouts/partials/func/hook.html
+++ b/layouts/partials/func/hook.html
@@ -58,17 +58,19 @@
 {{- /* if no file based hooks ran then check for folder based hooks */ -}}
 {{- if eq $loaded false -}}
   {{- $partialHookFolder := printf "layouts/partials/hooks/%s/" $context.hook -}}
-  {{- partial "debug.html" (dict
-    "message" (printf "running folder hooks for `%s`" (printf "%s" $context.hook))
-    "context" .
-    "severity" "info"
-    "level" 9
-  ) -}}
-  {{- range os.ReadDir $partialHookFolder -}}   
-    {{- if not .IsDir }}
-      {{- $partialHook := printf "%s%s" $partialHookFolder .Name -}}
-      {{- partial $partialHook $context $context.hook -}}
-      {{- $loaded = true -}}
+  {{- if fileExists $partialHookFolder -}}
+    {{- partial "debug.html" (dict
+      "message" (printf "running folder hooks for `%s`" (printf "%s" $context.hook))
+      "context" .
+      "severity" "info"
+      "level" 9
+    ) -}}
+    {{- range os.ReadDir $partialHookFolder -}}   
+      {{- if not .IsDir }}
+        {{- $partialHook := printf "%s%s" $partialHookFolder .Name -}}
+        {{- partial $partialHook $context $context.hook -}}
+        {{- $loaded = true -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/partials/func/hook.html
+++ b/layouts/partials/func/hook.html
@@ -55,6 +55,23 @@
   {{- end -}}
 {{- end -}}
 
+{{- /* if no file based hooks ran then check for folder based hooks */ -}}
+{{- if eq $loaded false -}}
+  {{- $partialHookFolder := printf "layouts/partials/hooks/%s/" $context.hook -}}
+  {{- partial "debug.html" (dict
+    "message" (printf "running folder hooks for `%s`" (printf "%s" $context.hook))
+    "context" .
+    "severity" "info"
+    "level" 9
+  ) -}}
+  {{- range os.ReadDir $partialHookFolder -}}   
+    {{- if not .IsDir }}
+      {{- $partialHook := printf "%s%s" $partialHookFolder .Name -}}
+      {{- partial $partialHook $context $context.hook -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{- /* send out a note if the hook is not used */ -}}
 {{- if eq $loaded false -}}
   {{- if not (in site.Params.dnb.hooks.disable_messages "unused_hooks") -}}

--- a/layouts/partials/func/hook.html
+++ b/layouts/partials/func/hook.html
@@ -68,6 +68,7 @@
     {{- if not .IsDir }}
       {{- $partialHook := printf "%s%s" $partialHookFolder .Name -}}
       {{- partial $partialHook $context $context.hook -}}
+      {{- $loaded = true -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This is currently merely a POC for the new folder hooks feature. It checks if the hook is configured as a folder and loads all particles inside that folder. No caching is done currently. Also no weighting for the order of execution. 

Discussion see #29 

ToDo:

- [ ] setup caching
- [ ] setup order (weight)
- [ ] look for unexpected issues along the road

Copying the text into the comments so I can change the PR text when this gets finalised.